### PR TITLE
Update tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "module": "commonjs",
+    "skipLibCheck": true,
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,


### PR DESCRIPTION
It's a problem with types definition for bitcoinjs-lib@5.2.0, It's not up to xchain to fix those types but you can use this workaround to keep working without typescript error in bitcoin-js package.